### PR TITLE
Feat/allow using null with date type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fokus-app/nestjs-mongoose-fps",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A filtration, pagination and sorting lib for NestJS using mongoose ORM",
   "main": "dist/index.js",
   "scripts": {

--- a/src/filter/parser.ts
+++ b/src/filter/parser.ts
@@ -40,7 +40,7 @@ export class FilterParser {
       for (const k of v) {
         this.transform(k);
       }
-    } else if (v instanceof Object) {
+    } else if (v instanceof Object && !(v instanceof Date)) {
       for (const key in v) {
         if (/^\$/.test(key)) {
           this.validateAllowedKey(key, v[key]);
@@ -70,8 +70,18 @@ export class FilterParser {
     if (propType === 'date') {
       if (value instanceof Object) {
         for (const key in value) {
-          value[key] = new Date(value[key]);
+          if (
+            value[key] == null ||
+            value[key] === 'null' ||
+            value[key] === ''
+          ) {
+            value[key] = null;
+          } else {
+            value[key] = new Date(value[key]);
+          }
         }
+      } else if (value == null || value === 'null' || value === '') {
+        value = null;
       } else {
         value = new Date(value);
       }

--- a/src/filter/validation.schema.ts
+++ b/src/filter/validation.schema.ts
@@ -11,7 +11,6 @@ export const schema = {
       anyOf: [
         {
           type: 'object',
-          additionalProperties: false,
           patternProperties: {
             '^[a-zA-Z].*$': {
               type: ['string', 'number', 'boolean', 'null'],
@@ -20,7 +19,6 @@ export const schema = {
         },
         {
           type: 'object',
-          additionalProperties: false,
           patternProperties: {
             '^[a-zA-Z].*$': {
               $ref: '#/definitions/comparison',
@@ -29,7 +27,6 @@ export const schema = {
         },
         {
           type: 'object',
-          additionalProperties: false,
           patternProperties: {
             '^[a-zA-Z].*$': {
               type: 'array',
@@ -41,7 +38,6 @@ export const schema = {
         },
         {
           type: 'object',
-          additionalProperties: false,
           patternProperties: {
             '^[a-zA-Z].*$': {
               $ref: '#/definitions/logical',
@@ -50,7 +46,6 @@ export const schema = {
         },
         {
           type: 'object',
-          additionalProperties: false,
           patternProperties: {
             '[$](and|or|nor)$': {
               type: 'array',
@@ -63,8 +58,7 @@ export const schema = {
       ],
     },
     logical: {
-      type: 'object',
-      additionalProperties: false,
+      type: 'object
       properties: {
         $not: {
           $ref: '#/definitions/comparison',
@@ -75,7 +69,6 @@ export const schema = {
       anyOf: [
         {
           type: 'object',
-          additionalProperties: false,
           properties: {
             $regex: {
               type: 'string',
@@ -87,7 +80,6 @@ export const schema = {
         },
         {
           type: 'object',
-          additionalProperties: false,
           patternProperties: {
             '^[$](eq|neq)$': {
               type: ['string', 'number', 'boolean', 'null'],
@@ -96,7 +88,6 @@ export const schema = {
         },
         {
           type: 'object',
-          additionalProperties: false,
           patternProperties: {
             '^[$](gt|gte|lt|lte)$': {
               type: ['string', 'number', 'object'],
@@ -105,7 +96,6 @@ export const schema = {
         },
         {
           type: 'object',
-          additionalProperties: false,
           patternProperties: {
             '^[$](in|nin)$': {
               type: 'array',

--- a/src/filter/validation.schema.ts
+++ b/src/filter/validation.schema.ts
@@ -58,7 +58,7 @@ export const schema = {
       ],
     },
     logical: {
-      type: 'object
+      type: 'object',
       properties: {
         $not: {
           $ref: '#/definitions/comparison',


### PR DESCRIPTION
This PR:
- Allows using `null` values for date types (useful in case you want to select date fields with no values)
Ex: `{"dateField": {"$eq": "nulll"}}`
- Fixies transforming `Date` objects
- Removes `additionalProperties` as it causes issues with nested `and` and `or`