### PR TITLE
Feat/allow using null with date type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fokus-app/nestjs-mongoose-fps",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A filtration, pagination and sorting lib for NestJS using mongoose ORM",
   "main": "dist/index.js",
   "scripts": {

--- a/src/filter/parser.ts
+++ b/src/filter/parser.ts
@@ -40,7 +40,7 @@ export class FilterParser {
       for (const k of v) {
         this.transform(k);
       }
-    } else if (v instanceof Object) {
+    } else if (v instanceof Object && !(v instanceof Date)) {
       for (const key in v) {
         if (/^\$/.test(key)) {
           this.validateAllowedKey(key, v[key]);
@@ -70,8 +70,18 @@ export class FilterParser {
     if (propType === 'date') {
       if (value instanceof Object) {
         for (const key in value) {
-          value[key] = new Date(value[key]);
+          if (
+            value[key] == null ||
+            value[key] === 'null' ||
+            value[key] === ''
+          ) {
+            value[key] = null;
+          } else {
+            value[key] = new Date(value[key]);
+          }
         }
+      } else if (value == null || value === 'null' || value === '') {
+        value = null;
       } else {
         value = new Date(value);
       }

--- a/src/filter/validator.spec.ts
+++ b/src/filter/validator.spec.ts
@@ -36,6 +36,39 @@ describe('Validator', () => {
       });
     });
 
+    it('should allow date queries', async () => {
+      const queries = [
+        { created_at: { $gt: '2023-12-31' } },
+        { created_at: { $gte: '2023-12-31' } },
+        { created_at: { $lt: '2023-12-31' } },
+        { created_at: { $lte: '2023-12-31' } },
+      ];
+
+      queries.forEach((query) => {
+        expect(validator.validate(query)).toBe(true);
+      });
+    });
+
+    it('should allow nested queries', async () => {
+      const queries = [
+        {
+          $and: [
+            { created_at: { $gt: '2023-12-31' } },
+            {
+              $or: [
+                { created_at: { $lt: '2023-12-31' } },
+                { created_at: { $eq: 'null' } },
+              ],
+            },
+          ],
+        },
+      ];
+
+      queries.forEach((query) => {
+        expect(validator.validate(query)).toBe(true);
+      });
+    });
+
     it('should not be valid', async () => {
       const queries = [
         { $unknown: 'audio' },


### PR DESCRIPTION
This PR: 
- Allows using null values for date types (useful in case you want to select date fields with no values)
Ex: {"dateField": {"$eq": "nulll"}}
- Fixies transforming Date objects